### PR TITLE
Changed jerk calculation so it is divided by seconds

### DIFF
--- a/src/main/java/frc/robot/commands/StopAtCollision.java
+++ b/src/main/java/frc/robot/commands/StopAtCollision.java
@@ -7,14 +7,13 @@ import frc.robot.lib.RioLogger;
 import frc.robot.subsystems.DriveTrain;
 import frc.robot.subsystems.NavxGyro;
 
-// If a collision is detected in auto mode, then stop the robot for 1 second
 public class StopAtCollision extends CommandBase {
     private NavxGyro gyro = new NavxGyro(SPI.Port.kMXP);
     private DriveTrain dt = new DriveTrain();
-    double lastWorldAccelX = 0.0;
-    double lastWorldAccelY = 0.0;
-    long lastSystemTime = 0;
-    final static double kCollisionJerkThreshold = 1.2; // Jerk (m/s^3) threshold
+    private double lastWorldAccelX = 0.0;
+    private double lastWorldAccelY = 0.0;
+    private long lastSystemTime = 0;
+    final static double kCollisionJerkThreshold = 1.2; // Jerk (m/s^3) threshold for detecting collisions
     public static boolean collisionDetected = false;
 
     public StopAtCollision(NavxGyro gyro, DriveTrain dt) {
@@ -31,12 +30,12 @@ public class StopAtCollision extends CommandBase {
         lastSystemTime = currSystemTime; // Sets the last time to the current one for the next iteration
 
         // Finds difference in acceleration in X direction between current and previous iteration
-        double currWorldAccelX = gyro.getWorldLinearAccelX(); // Gets the current X acceleration
+        double currWorldAccelX = gyro.getWorldLinearAccelX(); // Gets the current X acceleration (in G)
         double deltaAccelX = currWorldAccelX - lastWorldAccelX; // Change between the current and previous acceleration
         lastWorldAccelX = currWorldAccelX; // Sets the last acceleration to the current one for the next iteration
         
         // Finds difference in acceleration in X direction between current and previous iteration
-        double currWorldAccelY = gyro.getWorldLinearAccelY(); // Gets the current Y acceleration
+        double currWorldAccelY = gyro.getWorldLinearAccelY(); // Gets the current Y acceleration (in G)
         double deltaAccelY = currWorldAccelY - lastWorldAccelY; // Change between the current and previous acceleration
         lastWorldAccelY = currWorldAccelX; // Sets the last acceleration to the current one for the next iteration
 
@@ -56,6 +55,7 @@ public class StopAtCollision extends CommandBase {
         if (Math.abs(currentJerkY) > kCollisionJerkThreshold
                 && Math.abs(currentJerkX) > kCollisionJerkThreshold) {
 
+            // If jerk is greater than the threshold then there must have been a collision
             collisionDetected = true;
         } else {
             collisionDetected = false;

--- a/src/main/java/frc/robot/commands/StopAtCollision.java
+++ b/src/main/java/frc/robot/commands/StopAtCollision.java
@@ -102,6 +102,7 @@ public class StopAtCollision extends CommandBase {
         // First detect if there is a collision 
         // (if jerk is greater than threshold)
         DetectCollision();
+        OI.collision = collisionDetected;
         try {
             // If there is a collision stop the drive train
             StopIfCollision(collisionDetected);


### PR DESCRIPTION
Ok, so according to the [wikipedia page on Jerk](https://en.wikipedia.org/wiki/Jerk_(physics)), it says that it is the rate at which an object's acceleration changes with respect to time. So this means that you have to divide the change in acceleration by the change in time.

I know on the Kauai Labs doc page for detecting collisions it just finds the change in acceleration but I don't think that's actually right because the unit for jerk is m/s^3. If you just find the change in acceleration, that would be a unit of m/s^2, so you have to divide by seconds again to get jerk.

I think this will be more accurate than just finding the change in acceleration because jerk will take the difference in time between iterations into account. Because the difference between the iterations isn't constant if two moments have the same jerk, the change in acceleration might be different because the time between the iterations changed.

I added some comments in the file too. Also, it builds successfully. (Also we need to retest the jerk threshold for this)